### PR TITLE
feat(deadzone): only apply if both axes are inside

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,3 +97,10 @@ wpi.java.configureTestTasks(test)
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
 }
+
+// Compile as UTF-8
+compileJava.options.encoding = 'UTF-8'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -75,6 +75,8 @@ public final class Constants {
         public static final Vector<N3> ODOMETRY_STD_DEV = VecBuilder.fill(0.05, 0.05, 0.01);
 
         public static final double CARPET_BIAS = 1.05;
+
+        public static final double DEADZONE = 0.5;
     }
 
     public static class Arm {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -76,7 +76,7 @@ public final class Constants {
 
         public static final double CARPET_BIAS = 1.05;
 
-        public static final double DEADZONE = 0.5;
+        public static final double DEADZONE = 0.1;
     }
 
     public static class Arm {

--- a/src/main/java/frc/robot/commands/DriveWithJoysticks.java
+++ b/src/main/java/frc/robot/commands/DriveWithJoysticks.java
@@ -6,9 +6,13 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Subsystem;
+import frc.robot.RobotContainer;
 import frc.robot.Constants.DriveConstants;
+import frc.robot.Constants.FieldConstants;
 import frc.robot.poseestimation.PoseEstimation;
 import frc.robot.subsystems.drivetrain.Drivetrain;
 import frc.robot.utils.AllianceUtils;
@@ -24,6 +28,9 @@ public class DriveWithJoysticks implements Command {
     private Rotation2d fieldOrientationZeroOffset = new Rotation2d();
     private Sensitivity sensitivity;
 
+    private final Field2d leftJoystickGraph = new Field2d();
+    private final Field2d rightJoystickGraph = new Field2d();
+
     public DriveWithJoysticks(Drivetrain drivetrain, PoseEstimation poseEstimation, Joystick translation,
             Joystick rotation) {
         this.drivetrain = drivetrain;
@@ -33,6 +40,13 @@ public class DriveWithJoysticks implements Command {
         this.rotation = rotation;
         drivetrain.resetEncoders();
         sensitivity = new Sensitivity(poseEstimation);
+
+        RobotContainer.swerveTab.add("Left Joystick", leftJoystickGraph).withWidget(BuiltInWidgets.kField).withSize(3, 2);
+        RobotContainer.swerveTab.add("Right Joystick", rightJoystickGraph).withWidget(BuiltInWidgets.kField).withSize(3, 2);
+    }
+
+    private static void updateJoystickGraph(Field2d graph, double[] joystickValues) {
+        graph.setRobotPose(joystickValues[0] + FieldConstants.fieldLength / 2, joystickValues[1] + FieldConstants.fieldWidth / 2, new Rotation2d());
     }
 
     @Override
@@ -40,7 +54,10 @@ public class DriveWithJoysticks implements Command {
         double[] translationValues = DeadbandUtils.getXYWithDeadband(translation, DriveConstants.DEADZONE);
         double translationx = translationValues[0];
         double translationy = translationValues[1];
-        double r = DeadbandUtils.getXYWithDeadband(rotation, DriveConstants.DEADZONE)[1];
+        updateJoystickGraph(leftJoystickGraph, translationValues);
+        double[] rotationValues = DeadbandUtils.getXYWithDeadband(rotation, DriveConstants.DEADZONE);
+        double r = rotationValues[1];
+        updateJoystickGraph(rightJoystickGraph, rotationValues);
 
         boolean withinDeadband = translationx == 0 && translationy == 0 && r == 0;
 

--- a/src/main/java/frc/robot/commands/DriveWithJoysticks.java
+++ b/src/main/java/frc/robot/commands/DriveWithJoysticks.java
@@ -37,10 +37,10 @@ public class DriveWithJoysticks implements Command {
 
     @Override
     public void execute() {
-        double[] translationValues = DeadbandUtils.getXYWithDeadband(translation, 0.1);
+        double[] translationValues = DeadbandUtils.getXYWithDeadband(translation, DriveConstants.DEADZONE);
         double translationx = translationValues[0];
         double translationy = translationValues[1];
-        double r = DeadbandUtils.getXYWithDeadband(rotation, 0.1)[1];
+        double r = DeadbandUtils.getXYWithDeadband(rotation, DriveConstants.DEADZONE)[1];
 
         boolean withinDeadband = translationx == 0 && translationy == 0 && r == 0;
 

--- a/src/main/java/frc/robot/utils/DeadbandUtils.java
+++ b/src/main/java/frc/robot/utils/DeadbandUtils.java
@@ -10,7 +10,7 @@ public class DeadbandUtils {
         double yValue = -joystick.getX() * (joystick.getZ() + 1) / 2;
 
         // if one of the joystick axes are out of the deadzone, ignore it for both
-        boolean force = xValue > deadband || yValue > deadband;
+        boolean force = Math.abs(xValue) > deadband || Math.abs(yValue) > deadband;
 
         xValue = applyDeadband(xValue, deadband, 1.0, force);
         yValue = applyDeadband(yValue, deadband, 1.0, force);

--- a/src/main/java/frc/robot/utils/DeadbandUtils.java
+++ b/src/main/java/frc/robot/utils/DeadbandUtils.java
@@ -1,0 +1,83 @@
+
+package frc.robot.utils;
+
+import edu.wpi.first.wpilibj.Joystick;
+
+public class DeadbandUtils {
+    public static double[] getXYWithDeadband(Joystick joystick, double deadband) {
+        // Negative because joysticks are inverted
+        double xValue = -joystick.getY() * (joystick.getZ() + 1) / 2;
+        double yValue = -joystick.getX() * (joystick.getZ() + 1) / 2;
+
+        // if one of the joystick axes are out of the deadzone, ignore it for both
+        boolean force = xValue > deadband || yValue > deadband;
+
+        xValue = applyDeadband(xValue, deadband, 1.0, force);
+        yValue = applyDeadband(yValue, deadband, 1.0, force);
+
+        return new double[] { xValue, yValue };
+    }
+
+    // Copyright (c) FIRST and other WPILib contributors.
+    // Open Source Software; you can modify and/or share it under the terms of
+    // the WPILib BSD license file in the root directory of this project.
+    /**
+     * Returns 0.0 if the given value is within the specified range around zero. The
+     * remaining range
+     * between the deadband and the maximum magnitude is scaled from 0.0 to the
+     * maximum magnitude.
+     *
+     * @param value        Value to clip.
+     * @param deadband     Range around zero.
+     * @param maxMagnitude The maximum magnitude of the input. Can be infinite.
+     * @param force        Skip the deadband check and only scale the value
+     * @return The value after the deadband is applied.
+     */
+    private static double applyDeadband(double value, double deadband, double maxMagnitude, boolean force) {
+        if (Math.abs(value) > deadband || force) {
+            if (maxMagnitude / deadband > 1.0e12) {
+                // If max magnitude is sufficiently large, the implementation encounters
+                // roundoff error. Implementing the limiting behavior directly avoids
+                // the problem.
+                return value > 0.0 ? value - deadband : value + deadband;
+            }
+            if (value > 0.0) {
+                // Map deadband to 0 and map max to max.
+                //
+                // y - y₁ = m(x - x₁)
+                // y - y₁ = (y₂ - y₁)/(x₂ - x₁) (x - x₁)
+                // y = (y₂ - y₁)/(x₂ - x₁) (x - x₁) + y₁
+                //
+                // (x₁, y₁) = (deadband, 0) and (x₂, y₂) = (max, max).
+                // x₁ = deadband
+                // y₁ = 0
+                // x₂ = max
+                // y₂ = max
+                //
+                // y = (max - 0)/(max - deadband) (x - deadband) + 0
+                // y = max/(max - deadband) (x - deadband)
+                // y = max (x - deadband)/(max - deadband)
+                return maxMagnitude * (value - deadband) / (maxMagnitude - deadband);
+            } else {
+                // Map -deadband to 0 and map -max to -max.
+                //
+                // y - y₁ = m(x - x₁)
+                // y - y₁ = (y₂ - y₁)/(x₂ - x₁) (x - x₁)
+                // y = (y₂ - y₁)/(x₂ - x₁) (x - x₁) + y₁
+                //
+                // (x₁, y₁) = (-deadband, 0) and (x₂, y₂) = (-max, -max).
+                // x₁ = -deadband
+                // y₁ = 0
+                // x₂ = -max
+                // y₂ = -max
+                //
+                // y = (-max - 0)/(-max + deadband) (x + deadband) + 0
+                // y = max/(max - deadband) (x + deadband)
+                // y = max (x + deadband)/(max - deadband)
+                return maxMagnitude * (value + deadband) / (maxMagnitude - deadband);
+            }
+        } else {
+            return 0.0;
+        }
+    }
+}

--- a/src/main/java/frc/robot/utils/DeadbandUtils.java
+++ b/src/main/java/frc/robot/utils/DeadbandUtils.java
@@ -9,75 +9,12 @@ public class DeadbandUtils {
         double xValue = -joystick.getY() * (joystick.getZ() + 1) / 2;
         double yValue = -joystick.getX() * (joystick.getZ() + 1) / 2;
 
-        // if one of the joystick axes are out of the deadzone, ignore it for both
-        boolean force = Math.abs(xValue) > deadband || Math.abs(yValue) > deadband;
 
-        xValue = applyDeadband(xValue, deadband, 1.0, force);
-        yValue = applyDeadband(yValue, deadband, 1.0, force);
+        // only apply deadzone if both axes are inside
+        if (Math.abs(xValue) < deadband && Math.abs(yValue) < deadband) {
+            return new double[] { 0, 0 };
+        }
 
         return new double[] { xValue, yValue };
-    }
-
-    // Copyright (c) FIRST and other WPILib contributors.
-    // Open Source Software; you can modify and/or share it under the terms of
-    // the WPILib BSD license file in the root directory of this project.
-    /**
-     * Returns 0.0 if the given value is within the specified range around zero. The
-     * remaining range
-     * between the deadband and the maximum magnitude is scaled from 0.0 to the
-     * maximum magnitude.
-     *
-     * @param value        Value to clip.
-     * @param deadband     Range around zero.
-     * @param maxMagnitude The maximum magnitude of the input. Can be infinite.
-     * @param force        Skip the deadband check and only scale the value
-     * @return The value after the deadband is applied.
-     */
-    private static double applyDeadband(double value, double deadband, double maxMagnitude, boolean force) {
-        if (Math.abs(value) > deadband || force) {
-            if (maxMagnitude / deadband > 1.0e12) {
-                // If max magnitude is sufficiently large, the implementation encounters
-                // roundoff error. Implementing the limiting behavior directly avoids
-                // the problem.
-                return value > 0.0 ? value - deadband : value + deadband;
-            }
-            if (value > 0.0) {
-                // Map deadband to 0 and map max to max.
-                //
-                // y - y₁ = m(x - x₁)
-                // y - y₁ = (y₂ - y₁)/(x₂ - x₁) (x - x₁)
-                // y = (y₂ - y₁)/(x₂ - x₁) (x - x₁) + y₁
-                //
-                // (x₁, y₁) = (deadband, 0) and (x₂, y₂) = (max, max).
-                // x₁ = deadband
-                // y₁ = 0
-                // x₂ = max
-                // y₂ = max
-                //
-                // y = (max - 0)/(max - deadband) (x - deadband) + 0
-                // y = max/(max - deadband) (x - deadband)
-                // y = max (x - deadband)/(max - deadband)
-                return maxMagnitude * (value - deadband) / (maxMagnitude - deadband);
-            } else {
-                // Map -deadband to 0 and map -max to -max.
-                //
-                // y - y₁ = m(x - x₁)
-                // y - y₁ = (y₂ - y₁)/(x₂ - x₁) (x - x₁)
-                // y = (y₂ - y₁)/(x₂ - x₁) (x - x₁) + y₁
-                //
-                // (x₁, y₁) = (-deadband, 0) and (x₂, y₂) = (-max, -max).
-                // x₁ = -deadband
-                // y₁ = 0
-                // x₂ = -max
-                // y₂ = -max
-                //
-                // y = (-max - 0)/(-max + deadband) (x + deadband) + 0
-                // y = max/(max - deadband) (x + deadband)
-                // y = max (x + deadband)/(max - deadband)
-                return maxMagnitude * (value + deadband) / (maxMagnitude - deadband);
-            }
-        } else {
-            return 0.0;
-        }
     }
 }


### PR DESCRIPTION
Changes the deadzone calculations on the joystick to apply to both axes at once. If either axis is out of the deadzone, it will not be applied for either one.